### PR TITLE
Bug fix and additional feature.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+*.iml
+*.ipr
+*.iws

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
   <groupId>com.lambdaworks</groupId>
   <artifactId>lettuce</artifactId>
-  <version>2.2.0</version>
+  <version>2.2.0.SI</version>
 
   <packaging>jar</packaging>
 
   <name>lettuce</name>
   <description>Java redis client</description>
-  <url>http://github.com/wg/lettuce</url>
+  <url>https://github.com/mjssjmgithub/lettuce</url>
 
   <licenses>
     <license>
@@ -81,14 +81,14 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.1</version>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.0.4</version>
         <executions>
           <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
+            <id>attach-sources</id>
             <goals>
-              <goal>sign</goal>
+              <goal>jar</goal>
+              <goal>test-jar</goal>
             </goals>
           </execution>
         </executions>
@@ -101,22 +101,8 @@
   </properties>
 
   <scm>
-    <connection>scm:git:git://github.com/wg/lettuce.git</connection>
-    <developerConnection>scm:git:git://github.com/wg/lettuce.git</developerConnection>
-    <url>http://github.com/wg/lettuce</url>
+    <connection>scm:git:git@github.com:mjssjmgithub/lettuce.git</connection>
+    <developerConnection>scm:git:git@github.com:mjssjmgithub/lettuce.git</developerConnection>
+    <url>https://github.com/mjssjmgithub/lettuce</url>
   </scm>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <name>Sonatype Nexus Snapshots</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-    </snapshotRepository>
-
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <name>Nexus Release Repository</name>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
 </project>

--- a/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
+++ b/src/main/java/com/lambdaworks/redis/RedisAsyncConnection.java
@@ -1082,4 +1082,21 @@ public class RedisAsyncConnection<K, V> extends SimpleChannelUpstreamHandler {
         }
         return Double.toString(n);
     }
+
+    /**
+     * Add a ChannelHandler to the pipeline.
+     *
+     * @param handler the handler to add
+     */
+    public void addChannelHandler(ChannelHandler handler) {
+        Channel chan = channel;
+        if (chan != null && handler != null) {
+            ChannelPipeline pipeline = chan.getPipeline();
+            if (pipeline != null) {
+                List<String> names = pipeline.getNames();
+                int size = (names != null) ? names.size() : 0;
+                pipeline.addLast(Integer.valueOf(size).toString(), handler);
+            }
+        }
+    }
 }

--- a/src/test/java/com/lambdaworks/redis/ServerCommandTest.java
+++ b/src/test/java/com/lambdaworks/redis/ServerCommandTest.java
@@ -16,6 +16,7 @@ public class ServerCommandTest extends AbstractCommandTest {
     public void bgrewriteaof() throws Exception {
         String msg = "Background append only file rewriting started";
         assertEquals(msg, redis.bgrewriteaof());
+        Thread.sleep(4000);
     }
 
     @Test


### PR DESCRIPTION
I found an problem when issuing subsequent subscribe commands on a PubSub connection already handling incoming messages from Redis . Also, I added the ability to register a ChannelHander to a pipeline.  Since Redis subscriptions are bound to the Redis connection it is useful to know if the connection was severed.  This means all subscriptions on that connection are gone and messages may have been missed.
