### PR TITLE
Binary redis codec + JUnit test

### DIFF
--- a/src/main/java/com/lambdaworks/redis/codec/BinaryRedisCodec.java
+++ b/src/main/java/com/lambdaworks/redis/codec/BinaryRedisCodec.java
@@ -30,21 +30,11 @@ public class BinaryRedisCodec extends RedisCodec<byte[], byte[]> {
 
     @Override
     public byte[] encodeValue(byte[]  value) {
-    	return encode(value);
+        return encode(value);
     }
     
     private byte[] encode(byte[] value) {
-    	   try {
-               if(value instanceof byte[]){
-               	return (byte[])value;
-               }
-               else {
-               	throw new IOException("byte[] value was expected");
-               }
-           } catch (IOException e) {
-           	e.printStackTrace();
-               return null;
-           }
+        return (byte[]) value;
     }
 
     private byte[] decode(ByteBuffer bytes) {

--- a/src/main/java/com/lambdaworks/redis/codec/BinaryRedisCodec.java
+++ b/src/main/java/com/lambdaworks/redis/codec/BinaryRedisCodec.java
@@ -1,0 +1,59 @@
+package com.lambdaworks.redis.codec;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+
+/**
+ *  A {@link RedisCodec} that handles binary keys and values.
+ *  This is useful if you are storing non-UTF8 data in Redis
+ *  such as serialized objects or multimedia content.
+ *  
+ * @author Simone Scarduzio
+ */
+public class BinaryRedisCodec extends RedisCodec<byte[], byte[]> {
+
+    @Override
+    public byte[] decodeKey(ByteBuffer bytes) {
+        return decode(bytes);
+    }
+
+	@Override
+    public byte[] decodeValue(ByteBuffer bytes) {
+       return decode(bytes);
+    }
+
+    @Override
+    public byte[] encodeKey(byte[] key) {
+        return key;
+    }
+
+    @Override
+    public byte[] encodeValue(byte[]  value) {
+    	return encode(value);
+    }
+    
+    private byte[] encode(byte[] value) {
+    	   try {
+               if(value instanceof byte[]){
+               	return (byte[])value;
+               }
+               else {
+               	throw new IOException("byte[] value was expected");
+               }
+           } catch (IOException e) {
+           	e.printStackTrace();
+               return null;
+           }
+    }
+
+    private byte[] decode(ByteBuffer bytes) {
+   	 try {
+            byte[] ba = new byte[bytes.remaining()];
+            bytes.get(ba);
+            return ba;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/test/java/com/lambdaworks/redis/BinaryRedisCodecTest.java
+++ b/src/test/java/com/lambdaworks/redis/BinaryRedisCodecTest.java
@@ -1,0 +1,29 @@
+package com.lambdaworks.redis;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.lambdaworks.redis.codec.BinaryRedisCodec;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class BinaryRedisCodecTest extends AbstractCommandTest {
+	static RedisConnection<byte[], byte[]> binaryRedis = null;
+	
+	@BeforeClass
+	public static void setupBinaryClient(){
+		binaryRedis = new RedisClient(host, port).connect(new BinaryRedisCodec());
+	}
+	
+	@Test
+    public void decodeHugeBuffer() throws Exception {
+        byte[] huge = new byte[8192];
+        Arrays.fill(huge, (byte)'A');
+        binaryRedis.set(key.getBytes(), huge);
+        assertTrue(Arrays.equals(huge, binaryRedis.get(key.getBytes())));
+    }
+}
+
+


### PR DESCRIPTION
This adds support for reading and writing non-UTF8 strings from and to Redis. This is absolutely necessary if you want to store anything that is not a simple string.

Use cases:
- storing/retrieving serialized objects as values or keys
- storing/retrieving multimedia content as values or keys 
- storing/retrieving generic binary blobs as values or keys
