### PR TITLE
migrated to netty 4.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
   <dependencies>
    <dependency>
      <groupId>io.netty</groupId>
-     <artifactId>netty</artifactId>
-     <version>3.6.6.Final</version>
+     <artifactId>netty-all</artifactId>
+     <version>4.0.4.Final</version>
    </dependency>
 
    <dependency>

--- a/src/main/java/com/lambdaworks/redis/protocol/Command.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/Command.java
@@ -3,7 +3,7 @@
 package com.lambdaworks.redis.protocol;
 
 import com.lambdaworks.redis.RedisCommandInterruptedException;
-import org.jboss.netty.buffer.ChannelBuffer;
+import io.netty.buffer.ByteBuf;
 
 import java.util.concurrent.*;
 
@@ -155,7 +155,7 @@ public class Command<K, V, T> implements Future<T> {
      *
      * @param buf Buffer to write to.
      */
-    void encode(ChannelBuffer buf) {
+    void encode(ByteBuf buf) {
         buf.writeByte('*');
         writeInt(buf, 1 + (args != null ? args.count() : 0));
         buf.writeBytes(CRLF);
@@ -175,7 +175,7 @@ public class Command<K, V, T> implements Future<T> {
      * @param buf   Buffer to write to.
      * @param value Value to write.
      */
-    protected static void writeInt(ChannelBuffer buf, int value) {
+    protected static void writeInt(ByteBuf buf, int value) {
         if (value < 10) {
             buf.writeByte('0' + value);
             return;

--- a/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
+++ b/src/main/java/com/lambdaworks/redis/protocol/CommandHandler.java
@@ -2,9 +2,8 @@
 
 package com.lambdaworks.redis.protocol;
 
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.*;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.*;
 
 import java.util.concurrent.BlockingQueue;
 
@@ -14,9 +13,10 @@ import java.util.concurrent.BlockingQueue;
  *
  * @author Will Glozer
  */
-public class CommandHandler<K, V> extends SimpleChannelHandler {
+@ChannelHandler.Sharable
+public class CommandHandler<K, V> extends ChannelDuplexHandler {
     protected BlockingQueue<Command<K, V, ?>> queue;
-    protected ChannelBuffer buffer;
+    protected ByteBuf buffer;
     protected RedisStateMachine<K, V> rsm;
 
     /**
@@ -29,32 +29,41 @@ public class CommandHandler<K, V> extends SimpleChannelHandler {
     }
 
     @Override
-    public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
-        buffer = ChannelBuffers.dynamicBuffer(ctx.getChannel().getConfig().getBufferFactory());
+    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
+        buffer = ctx.alloc().heapBuffer();
         rsm = new RedisStateMachine<K, V>();
     }
 
     @Override
-    public void writeRequested(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
-        Command<?, ?, ?> cmd = (Command<?, ?, ?>) e.getMessage();
-        Channel channel = ctx.getChannel();
-        ChannelBuffer buf = ChannelBuffers.dynamicBuffer(channel.getConfig().getBufferFactory());
-        cmd.encode(buf);
-        Channels.write(ctx, e.getFuture(), buf);
+    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
+        buffer.release();
     }
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
-        ChannelBuffer input = (ChannelBuffer) e.getMessage();
-        if (!input.readable()) return;
-
-        buffer.discardReadBytes();
-        buffer.writeBytes(input);
-
-        decode(ctx, buffer);
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ByteBuf input = (ByteBuf) msg;
+        try {
+            if (!input.isReadable()) return;
+    
+            buffer.discardReadBytes();
+            buffer.writeBytes(input);
+    
+            decode(ctx, buffer);
+        } finally {
+            input.release();
+        }
     }
 
-    protected void decode(ChannelHandlerContext ctx, ChannelBuffer buffer) throws InterruptedException {
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise) throws Exception {
+        Command<?, ?, ?> cmd = (Command<?, ?, ?>) msg;
+        Channel channel = ctx.channel();
+        ByteBuf buf = ctx.alloc().heapBuffer();
+        cmd.encode(buf);
+        ctx.write(buf, promise);
+    }
+
+    protected void decode(ChannelHandlerContext ctx, ByteBuf buffer) throws InterruptedException {
         while(!queue.isEmpty() && rsm.decode(buffer, queue.peek().getOutput())) {
             Command<K, V, ?> cmd = queue.take();
             cmd.complete();

--- a/src/main/java/com/lambdaworks/redis/pubsub/RedisPubSubConnection.java
+++ b/src/main/java/com/lambdaworks/redis/pubsub/RedisPubSubConnection.java
@@ -6,7 +6,7 @@ import com.lambdaworks.redis.RedisAsyncConnection;
 import com.lambdaworks.redis.codec.RedisCodec;
 import com.lambdaworks.redis.protocol.Command;
 import com.lambdaworks.redis.protocol.CommandArgs;
-import org.jboss.netty.channel.*;
+import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.reflect.Array;
 import java.util.*;
@@ -83,8 +83,8 @@ public class RedisPubSubConnection<K, V> extends RedisAsyncConnection<K, V> {
     }
 
     @Override
-    public synchronized void channelConnected(ChannelHandlerContext ctx, ChannelStateEvent e) throws Exception {
-        super.channelConnected(ctx, e);
+    public synchronized void channelActive(ChannelHandlerContext ctx) throws Exception {
+        super.channelActive(ctx);
 
         if (channels.size() > 0) {
             subscribe(toArray(channels));
@@ -99,8 +99,8 @@ public class RedisPubSubConnection<K, V> extends RedisAsyncConnection<K, V> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public void messageReceived(ChannelHandlerContext ctx, MessageEvent e) throws Exception {
-        PubSubOutput<K, V> output = (PubSubOutput<K, V>) e.getMessage();
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        PubSubOutput<K, V> output = (PubSubOutput<K, V>) msg;
         for (RedisPubSubListener<K, V> listener : listeners) {
             switch (output.type()) {
                 case message:

--- a/src/test/java/com/lambdaworks/redis/protocol/StateMachineTest.java
+++ b/src/test/java/com/lambdaworks/redis/protocol/StateMachineTest.java
@@ -6,8 +6,8 @@ import com.lambdaworks.redis.RedisException;
 import com.lambdaworks.redis.codec.RedisCodec;
 import com.lambdaworks.redis.codec.Utf8StringCodec;
 import com.lambdaworks.redis.output.*;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -61,7 +61,7 @@ public class StateMachineTest {
     @Test
     public void multi() throws Exception {
         CommandOutput<String, String, List<String>> output = new ValueListOutput<String, String>(codec);
-        ChannelBuffer buffer = buffer("*2\r\n$-1\r\n$2\r\nok\r\n");
+        ByteBuf buffer = buffer("*2\r\n$-1\r\n$2\r\nok\r\n");
         assertTrue(rsm.decode(buffer, output));
         assertEquals(Arrays.asList(null, "ok"), output.get());
     }
@@ -85,7 +85,7 @@ public class StateMachineTest {
         assertEquals(State.Type.SINGLE, State.Type.valueOf("SINGLE"));
     }
 
-    protected ChannelBuffer buffer(String content) {
-        return ChannelBuffers.copiedBuffer(content, charset);
+    protected ByteBuf buffer(String content) {
+        return Unpooled.copiedBuffer(content, charset);
     }
 }


### PR DESCRIPTION
As netty 4 API has been fixed now, I made lettuce working with netty 4.0.4.Final.

This passes all 219 tests with no complaints, in Mac OS X 10.8.4 / Java 1.7.0_11.

Aside from find-and-replace changes, there are a few changes like
- `ChannelInitializer` instead of `ChannelPipelineFactory` and simplified `ConnectionWatchdog.run()`
- `@ChannelHandler.Sharable` annotation to each `ChannelHandler` classes, to make the multiplicity checker happy during reconnection
- Manually releasing ByteBuf, as netty 4 requires it, as well as manual HashedWheelTimer stopping
- `Command.output != null` checks to safely ignore responses from timed out commands. This makes the `ClientTask.timeout()` the happy

Please review the changes and I'd be happy to have it merged to your repository, or possibly in a separate branch for netty 4.

Many thanks for making this awesome library!
